### PR TITLE
Clarify Playwright usage instructions

### DIFF
--- a/src/frontend/life-sync-react-client/package.json
+++ b/src/frontend/life-sync-react-client/package.json
@@ -8,7 +8,9 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint src --ignore-path .gitignore",
-    "check-types": "tsc --project tsconfig.json --pretty --noEmit"
+    "check-types": "tsc --project tsconfig.json --pretty --noEmit",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.52.1",
@@ -50,7 +52,8 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.2.0",
     "vite": "^5.4.1",
-    "vitest": "^3.0.5"
+    "vitest": "^3.0.5",
+    "@playwright/test": "^1.48.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-arm64-gnu": "^4.0.0"

--- a/src/frontend/life-sync-react-client/playwright.config.ts
+++ b/src/frontend/life-sync-react-client/playwright.config.ts
@@ -1,0 +1,42 @@
+/**
+ * Playwright configuration for Life Sync React frontend end-to-end tests.
+ *
+ * Installation:
+ *   npm install --save-dev @playwright/test
+ *   npx playwright install --with-deps chromium
+ *
+ * Running tests:
+ *   npm run test:e2e           # headless (default)
+ *   npm run test:e2e:headed    # run in headed mode
+ *
+ *   You can override the base URL by exporting PLAYWRIGHT_BASE_URL
+ *   (for example when targeting a deployed preview environment).
+ */
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173';
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL,
+    headless: true,
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm start',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: devices['Desktop Chrome'],
+    },
+  ],
+});

--- a/src/frontend/life-sync-react-client/tests/e2e/example.spec.ts
+++ b/src/frontend/life-sync-react-client/tests/e2e/example.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+// Run with: npx playwright test tests/e2e/example.spec.ts
+// Ensure the dev server is running via the configured webServer (npm start).
+// Add --headed to the command to debug the scenario in a browser window.
+
+test.describe('Life Sync React App', () => {
+  test('should display the home page', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' });
+
+    await expect(page).toHaveTitle(/life sync/i);
+
+    const logoButton = page.getByRole('button', { name: /life sync/i });
+    await expect(logoButton).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- document how to override the Playwright base URL when running tests
- add guidance for debugging in headed mode and wait for network idle during navigation

## Testing
- npm run test:e2e *(fails: playwright CLI unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eaa17e6824832397a3c22f5768cffa