### PR TITLE
Adopt .NET 10 preview dependencies across backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ LifeSync aims to provide a unified platform for managing personal tasks on a dai
 ## Technologies Used
 
 ### Backend
-- .NET 9
+- .NET 10 (preview)
 - ASP.NET Core
 - Entity Framework Core
 
@@ -44,7 +44,18 @@ LifeSync aims to provide a unified platform for managing personal tasks on a dai
 
 Follow these steps to set up your development environment for LifeSync.
 
-### 1. Install and Configure MSSQL Developer Edition
+### 1. Install the .NET 10 Preview SDK
+
+1. **Download & Install:**
+   - Install the latest [.NET 10 preview SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) to ensure compatibility with the backend projects.
+   - When using Visual Studio, select workloads that include preview features or enable preview SDK usage in the IDE settings.
+
+2. **Verify Installation:**
+   - Run `dotnet --info` to confirm the `10.0.0` preview SDK is available and set as the default for this repository.
+
+---
+
+### 2. Install and Configure MSSQL Developer Edition
 
 1. **Download & Install:**
    - Download [MSSQL Developer Edition](https://www.microsoft.com/en-us/sql-server/sql-server-downloads) and run the installer. Follow the prompts in the installation wizard.
@@ -58,7 +69,7 @@ Follow these steps to set up your development environment for LifeSync.
 
 ---
 
-### 2. Configure Local Secrets for ASP.NET Core
+### 3. Configure Local Secrets for ASP.NET Core
 
 To securely store sensitive information (e.g., JWT secret, database credentials), use ASP.NET Core’s user secrets.
 
@@ -102,7 +113,7 @@ To securely store sensitive information (e.g., JWT secret, database credentials)
 
 ---
 
-### 3. Apply Entity Framework Core Migrations
+### 4. Apply Entity Framework Core Migrations
 
 1. **Update the Connection String:**
    - Ensure your ASP.NET Core configuration (in *appsettings.json* or via user secrets) correctly points to your `LifeSync` MSSQL database.

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS dev
+FROM mcr.microsoft.com/dotnet/sdk:10.0-preview AS dev
 WORKDIR /app
 
 # restore
@@ -20,7 +20,7 @@ WORKDIR /app/LifeSync.API
 RUN dotnet publish "LifeSync.API.csproj" -c Release -o /out
 
 #Stage 3: Run Stage
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS run
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-preview AS run
 WORKDIR /app
 COPY --from=build /out ./
 ENTRYPOINT [ "dotnet", "LifeSync.API.dll" ]

--- a/src/backend/src/LifeSync.API/LifeSync.API.csproj
+++ b/src/backend/src/LifeSync.API/LifeSync.API.csproj
@@ -1,11 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <RootNamespace>LifeSync.API</RootNamespace>
         <UserSecretsId>d97a589c-80bf-4505-b882-b57037de713c</UserSecretsId>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <UsePreviewVersions>true</UsePreviewVersions>
     </PropertyGroup>
 
     <ItemGroup>
@@ -13,15 +14,15 @@
         <PackageReference Include="AWSSDK.SecretsManager" Version="3.7.400.45"/>
         <PackageReference Include="FastEndpoints" Version="6.0.0"/>
         <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0-preview.5.24306.4"/>
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0-preview.5.24306.4"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-preview.5.24306.4"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0-preview.5.24281.2"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0-preview.5.24281.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0-preview.5.24281.2"/>
         <PackageReference Include="Serilog.AspNetCore" Version="9.0.0"/>
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0"/>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>

--- a/src/backend/src/LifeSync.API/Persistence/Migrations/20251009190327_Initial.Designer.cs
+++ b/src/backend/src/LifeSync.API/Persistence/Migrations/20251009190327_Initial.Designer.cs
@@ -20,7 +20,7 @@ namespace LifeSync.API.Persistence.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "9.0.0")
+                .HasAnnotation("ProductVersion", "10.0.0-preview.5.24281.2")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);

--- a/src/backend/src/LifeSync.API/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/backend/src/LifeSync.API/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace LifeSync.API.Persistence.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "9.0.0")
+                .HasAnnotation("ProductVersion", "10.0.0-preview.5.24281.2")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);

--- a/src/backend/src/LifeSync.API/Secrets/SecretsManager.cs
+++ b/src/backend/src/LifeSync.API/Secrets/SecretsManager.cs
@@ -9,7 +9,7 @@ namespace LifeSync.API.Secrets;
 /// Loads secrets from local secrets storage or AWS Secrets Manager
 /// based on current application environment
 /// To see more about local secrets storage -
-/// <see cref="https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-9.0&tabs=windows"/>
+/// <see cref="https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-10.0&tabs=windows"/>
 /// To see more about AWS Secrets Manager - 
 /// <see cref="https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets_cache-net.html"/>
 /// </summary>

--- a/src/backend/src/LifeSync.Common/LifeSync.Common.csproj
+++ b/src/backend/src/LifeSync.Common/LifeSync.Common.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <UsePreviewVersions>true</UsePreviewVersions>
     </PropertyGroup>
 
 </Project>

--- a/src/backend/tests/LifeSync.Tests.Unit/LifeSync.Tests.Unit.csproj
+++ b/src/backend/tests/LifeSync.Tests.Unit/LifeSync.Tests.Unit.csproj
@@ -1,17 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <RootNamespace>LifeSync.UnitTests</RootNamespace>
+        <UsePreviewVersions>true</UsePreviewVersions>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
         <PackageReference Include="FluentAssertions" Version="7.0.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0-preview.5.24281.2"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
         <PackageReference Include="NSubstitute" Version="5.3.0"/>
         <PackageReference Include="xunit" Version="2.9.2"/>


### PR DESCRIPTION
## Summary
- upgrade ASP.NET Core and Entity Framework Core package references to the .NET 10 preview builds and allow preview usage in backend projects
- refresh EF Core migration metadata and secrets documentation links to reference the .NET 10 toolchain
- document the .NET 10 preview SDK requirement in the setup instructions

## Testing
- not run (dotnet CLI is unavailable in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d1e9c9fc83239d8633b571dd4098)